### PR TITLE
1 add option to select type of downloaded expression values

### DIFF
--- a/src/grein_loader/load_dataset.py
+++ b/src/grein_loader/load_dataset.py
@@ -26,6 +26,10 @@ def load_dataset(gse_id: str, download_type: str="RAW") -> Tuple[dict, dict, pan
         :return: description, metadata, count_matrix of the GREIN dataset
         :rtype: description:dict, metadata:dictionary, count_matrix:pandas dataframe
     """
+    if download_type != "RAW" and download_type != "NORMALIZED":
+        LOGGER.error("Invalid download_type passed. Value must either by 'RAW' or 'NORMALIZED'.")
+        raise ValueError("Invalid download_type passed. Value must either by 'RAW' or 'NORMALIZED'.")
+
     payloads = utils.GreinLoaderUtils(gse_id)
     # create the unique random string used later for nonce parameter in url
     n = utils.GreinLoaderUtils.get_random_url_string_parameter()
@@ -157,7 +161,7 @@ def load_dataset(gse_id: str, download_type: str="RAW") -> Tuple[dict, dict, pan
                 "Origin": "http://www.ilincs.org",
                 "Referer": "http://www.ilincs.org/apps/grein/?gse=" + gse_id
             },
-            data=payloads.description_formdata(100))
+            data=payloads.description_formdata(100))  # Bruh wtf moment ??? 
         description_r.raise_for_status()
     except requests.exceptions.HTTPError as err:
         LOGGER.error(f"Dataset description for {gse_id} not received: ", err)

--- a/src/grein_loader/load_dataset.py
+++ b/src/grein_loader/load_dataset.py
@@ -13,10 +13,8 @@ import logging
 import json
 import pandas
 from typing import Tuple
-#from .exceptions import GreinLoaderException
-#from . import utils
-from exceptions import GreinLoaderException
-import utils
+from .exceptions import GreinLoaderException
+from . import utils
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/grein_loader/utils.py
+++ b/src/grein_loader/utils.py
@@ -33,6 +33,9 @@ class GreinLoaderUtils:
     def count_matrix_parameter(self):
         return '["18#0|m|{\\"method\\":\\"update\\",\\"data\\":{\\"counts_rows_selected\\":[],\\"counts_rows_current\\":[],\\"counts_rows_all\\":[],\\"counts_state\\":null,\\"counts_search\\":\\"\\",\\"counts_cell_clicked\\":{},\\".clientdata_output_downloadcounts_hidden\\":false}}"]'
 
+    def count_matrix_normalized(self):
+        return '["19#0|m|{\\"method\\":\\"update\\",\\"data\\":{\\"counts_choice\\":\\"Normalized\\"}}"]'
+    
     def raw_form_start(self):
         return "draw=1&columns%5B0%5D%5Bdata%5D=0&columns%5B0%5D%5Bname%5D=&columns%5B0%5D%5Bsearchable%5D=true&columns%5B0%5D%5Borderable%5D=false&columns%5B0%5D%5Bsearch%5D%5Bvalue%5D=&columns%5B0%5D%5Bsearch%5D%5Bregex%5D=false"
 


### PR DESCRIPTION
added download_type option RAW/NORMALIZED to load_dataset method signature. 
Used additional request for requesting the normalized count matrix from grein, by intriducing a new streaming parameter in the utilils.py (count_matrix_normalized)